### PR TITLE
Fix controllers retrieval and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ An improved Python library for interacting with Control4 systems.
 
 ```bash
 pip install -e .
+```
+
+## Usage
+
+See `examples/example_usage.py` for a complete example of authenticating and
+controlling a light.  Make sure the package dependencies are installed and
+replace the placeholder credentials with your own Control4 account details.

--- a/customControl4/account.py
+++ b/customControl4/account.py
@@ -78,7 +78,9 @@ class Account:
                 text = await response.text()
                 await check_response_for_error(text)
                 json_data = json.loads(text)
-                return json_data.get("account", {})
+                account_info = json_data.get("account", {})
+                controllers = account_info.get("controllers", [])
+                return controllers
 
     async def get_director_token(self, controller_common_name):
         """Retrieves a director bearer token for local communication with the controller."""

--- a/examples/example_usage.py
+++ b/examples/example_usage.py
@@ -10,10 +10,10 @@ async def main():
 
     # Get controllers and select one
     controllers = await account.get_controllers()
-    controller_name = controllers.get("controllerCommonName")
-    if not controller_name:
+    if not controllers:
         print("No controllers found.")
         return
+    controller_name = controllers[0].get("controllerCommonName")
 
     # Get director token
     director_token = await account.get_director_token(controller_name)


### PR DESCRIPTION
## Summary
- properly return controller list in `Account.get_controllers`
- update example to use controller list
- finish README installation section

## Testing
- `python -m compileall -q customControl4 examples`