### PR TITLE
Add configurable application key

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ An improved Python library for interacting with Control4 systems.
 
 ```bash
 pip install -e .
+```
+
+## Application Key
+
+The `Account` class uses an application key when authenticating with the
+Control4 API.  By default the library includes a built in key, but you can
+provide your own either through the `Account` constructor or by setting the
+`CONTROL4_APPLICATION_KEY` environment variable.


### PR DESCRIPTION
## Summary
- allow application key to be set when creating `Account`
- check `CONTROL4_APPLICATION_KEY` env var for custom key
- document application key configuration

## Testing
- `python -m py_compile customControl4/account.py`